### PR TITLE
refactor: use static alloc, remove unnecessary Option<T> in pick

### DIFF
--- a/src/affirmation.rs
+++ b/src/affirmation.rs
@@ -1,11 +1,11 @@
 use crate::random;
 
 #[derive(Debug)]
-pub struct Affirmation {
-    affirmations: Vec<String>,
+pub struct Affirmation<'a> {
+    affirmations: [&'a str; 6],
 }
 
-impl Affirmation {
+impl<'a> Affirmation<'a> {
     pub fn new() -> Self {
         let affirmations = [
             "You're beautiful",
@@ -14,14 +14,12 @@ impl Affirmation {
             "You've got this",
             "You can do all things",
             "Go get it",
-        ]
-        .map(String::from)
-        .to_vec();
+        ];
 
         Affirmation { affirmations }
     }
 
-    pub fn random(&self) -> String {
-        random::pick(&self.affirmations).unwrap_or("You're the best".to_string())
+    pub fn random(&self) -> &'a str {
+        random::pick(&self.affirmations)
     }
 }

--- a/src/formatter/color.rs
+++ b/src/formatter/color.rs
@@ -1,20 +1,18 @@
 use crate::random;
 
 #[derive(Debug)]
-pub struct Color {
-    colors: Vec<String>,
+pub struct Color<'a> {
+    colors: [&'a str; 6],
 }
 
-impl Color {
+impl<'a> Color<'a> {
     pub fn new() -> Self {
-        let colors: Vec<String> = ["red", "blue", "green", "yellow", "magenta", "cyan"]
-            .map(String::from)
-            .to_vec();
+        let colors = ["red", "blue", "green", "yellow", "magenta", "cyan"];
 
         Color { colors }
     }
 
-    pub fn random(&self) -> String {
-        random::pick(&self.colors).unwrap_or("yellow".to_string())
+    pub fn random(&self) -> &'a str {
+        random::pick(&self.colors)
     }
 }

--- a/src/formatter/emoji.rs
+++ b/src/formatter/emoji.rs
@@ -1,26 +1,18 @@
 use crate::random;
 
 #[derive(Debug)]
-pub struct Emoji {
-    emojis: Vec<String>,
+pub struct Emoji<'a> {
+    emojis: [&'a str; 7],
 }
 
-impl Emoji {
+impl<'a> Emoji<'a> {
     pub fn new() -> Self {
-        let emojis: Vec<String> = vec!["😍", "😎", "🧸", "😉", "👍", "💪", "✨"]
-            .into_iter()
-            .map(String::from)
-            .collect();
+        let emojis = ["😍", "😎", "🧸", "😉", "👍", "💪", "✨"];
 
         Emoji { emojis }
     }
 
-    pub fn random(&self) -> String {
-        let emoji = random::pick(&self.emojis);
-
-        match emoji {
-            Some(value) => value,
-            None => "💙".to_string(),
-        }
+    pub fn random(&self) -> &'a str {
+        random::pick(&self.emojis)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,5 +8,5 @@ use formatter::format;
 pub fn affirm(name: &str) -> String {
     let affirmation = Affirmation::new().random();
 
-    format(&affirmation, &name)
+    format(affirmation, name)
 }

--- a/src/random.rs
+++ b/src/random.rs
@@ -1,6 +1,6 @@
 use rand::Rng;
 
-pub fn pick<T: Clone>(vec: &Vec<T>) -> Option<T> {
-    let random_index: usize = rand::thread_rng().gen_range(0..vec.len());
-    vec.get(random_index).cloned()
+pub fn pick<'a, T: ?Sized>(items: &[&'a T]) -> &'a T {
+    let random_index: usize = rand::thread_rng().gen_range(0..items.len());
+    items.get(random_index).unwrap()
 }


### PR DESCRIPTION
### Changes
- Uses static allocation for predefined strings, this causes no heap allocations for `Color`, `Emoji`, and `Affirmation`
- Fix `pick` function to explicitly unwrap, since picking an item in a `&[&'a T]` (or `&[T]`) is guaranteed to yield an item
- Fix clippy lints (except one) `cargo clippy -- -D warnings`